### PR TITLE
Add missing <iostream> for std::clog.

### DIFF
--- a/glow/util.cpp
+++ b/glow/util.cpp
@@ -25,6 +25,8 @@
 #ifdef _WIN32
 #define NOMINMAX
 #include <Windows.h>
+#else
+#include <iostream>
 #endif
 
 namespace glow


### PR DESCRIPTION
Fixes build on macOS 15.6.1.